### PR TITLE
fix: use list not iterator

### DIFF
--- a/main.py
+++ b/main.py
@@ -184,11 +184,13 @@ def _main() -> None:
                 )
                 for fulltext_metadata in tqdm(fulltext_metadata_collection):
                     fulltext_for_domain_dict[fulltext_metadata.hash] = {
-                        "text": map(
-                            tokenize,
-                            _fetch_fulltext_with_fulltext_hash(
-                                database_cursor, fulltext_metadata.hash
-                            ),
+                        "text": list(
+                            map(
+                                tokenize,
+                                _fetch_fulltext_with_fulltext_hash(
+                                    database_cursor, fulltext_metadata.hash
+                                ),
+                            )
                         ),
                         "timestamp": fulltext_metadata.timestamp,
                         "uri": fulltext_metadata.uri,


### PR DESCRIPTION
Commit 5dc477f1765828d57f8e3fff96fa4de16c014fd1
introduced a bug by trying to write an iterator to a `YAML` file.

This bug is easily fixed by simply turning the
iterator into a list.

This is how the output with the iterator looked
like:

```yaml
text-entry:
  da39a3ee5e6b4b0d3255bfef95601890afd80709:
    text: !!python/object/apply:builtins.map
    - &id001 !!python/name:nb_tokenizer.tokenize ''
    - !!python/object/apply:builtins.iter
      args:
      - []
      state: 0
    timestamp: '20190219'
    uri: https://www.gat.no/
  c4fe03c3ebf4a10a5e7d7f83ba988af51a36da35:
    text: !!python/object/apply:builtins.map
```