### PR TITLE
fix: prepare to replace pyyaml with ruamel.yaml

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -22,6 +22,12 @@ pylint==3.2.0
     # via -r lint-requirements.in
 pyyaml==6.0.1
     # via -r requirements.txt
+ruamel-yaml==0.18.6
+    # via -r requirements.txt
+ruamel-yaml-clib==0.2.8
+    # via
+    #   -r requirements.txt
+    #   ruamel-yaml
 tomlkit==0.12.5
     # via pylint
 tqdm==4.66.4

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ psycopg2-binary # Should not be used in production, see https://www.psycopg.org/
 pyyaml
 tqdm
 nb_tokenizer
+ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,9 @@ psycopg2-binary==2.9.9
     # via -r requirements.in
 pyyaml==6.0.1
     # via -r requirements.in
+ruamel-yaml==0.18.6
+    # via -r requirements.in
+ruamel-yaml-clib==0.2.8
+    # via ruamel-yaml
 tqdm==4.66.4
     # via -r requirements.in

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,5 +18,11 @@ pytest==8.2.0
     # via -r test-requirements.in
 pyyaml==6.0.1
     # via -r requirements.txt
+ruamel-yaml==0.18.6
+    # via -r requirements.txt
+ruamel-yaml-clib==0.2.8
+    # via
+    #   -r requirements.txt
+    #   ruamel-yaml
 tqdm==4.66.4
     # via -r requirements.txt


### PR DESCRIPTION
# Motivation

`pyyaml` struggles to dump a `dict` that contains
a `list` that contains a `dict` that contains
unicode.

Replacing it with `ruamel.yaml` should fix this.

# Future work

The next commit will replacing the yaml dumping.